### PR TITLE
Remove undef warnings

### DIFF
--- a/templates/client/index.html.ep
+++ b/templates/client/index.html.ep
@@ -181,7 +181,7 @@
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="request_form">
 
-                % my $object = session 'object';
+                % my $object = session('object') || '';
                 % my $command = session 'command';
 
                 <div class="row">


### PR DESCRIPTION
The object has not been defined in session until first command is run,
and so produces 4 undef warnings from "eq", every time the page is loaded.