### PR TITLE
Eliminating double insertion of value

### DIFF
--- a/lib/EppDemoClient.pm
+++ b/lib/EppDemoClient.pm
@@ -703,9 +703,6 @@ sub startup {
                 $info->{ $status } = $s;
                 $status .= " ";
             }
-
-            _text_element_into( $epp_frame, 'dkhm:contact_validated', $info, 'validated' );
-
         }
 
         my $contact_created_element = ($epp_frame->getElementsByTagName('contact:creData'))[0];


### PR DESCRIPTION
Removed line doing the same as is done under the extension part, the …extension part is kept so standard values are kept separate from extensions, gives a better feedback on what is what