### PR TITLE
Reordered parameters

### DIFF
--- a/lib/EppDemoClient.pm
+++ b/lib/EppDemoClient.pm
@@ -260,8 +260,8 @@ sub get_request_frame {
     # also sets session('domain' => $value)
     #
     $self->generic_param_to_frame('domain',               $frame, 'setDomain', 'addDomain');
-    $self->generic_param_to_frame('period',               $frame, 'setPeriod');
     $self->generic_param_to_frame('curExpDate',           $frame, 'setCurExpDate');
+    $self->generic_param_to_frame('period',               $frame, 'setPeriod');
     $self->generic_param_to_frame('host',                 $frame, 'setHost', 'addHost');
     $self->generic_param_to_frame('new_host',             $frame, 'chgName');
     $self->generic_param_to_frame('userid',               $frame, 'setContact', 'addContact');


### PR DESCRIPTION
The `period` is coming before the `curExpDate` which does not comply with the XSD.

See issue #34 